### PR TITLE
generate-project-badges: access collection size in the right way

### DIFF
--- a/generate-project-badges.groovy
+++ b/generate-project-badges.groovy
@@ -72,7 +72,7 @@ def lines = readme.readLines()
 println "Updating ${readme}"
 lines[3..(lines.size() - 1)].join('\n')
 readme.newWriter().withWriter { w ->
-        w << "[![Apache Sling](https://sling.apache.org/res/logos/sling.png)](https://sling.apache.org)\n\n${badges.join('')}\n${lines[3..(lines.size - 1)].join('\n')}\n"
+        w << "[![Apache Sling](https://sling.apache.org/res/logos/sling.png)](https://sling.apache.org)\n\n${badges.join('')}\n${lines[3..(lines.size() - 1)].join('\n')}\n"
 }
 
 println 'Update complete!'


### PR DESCRIPTION
Use size() instead of size for the collection; this might've worked by accident but is not guaranteed.