### PR TITLE
SLING-12094 - Use GitHub for the Maven scm.url value

### DIFF
--- a/scripts/update-pom-scm.sh
+++ b/scripts/update-pom-scm.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -eu
+
+if [ ! -f pom.xml ]; then
+    echo "No pom.xml, skipping"
+    exit 0
+fi
+
+origin=$(git remote get-url origin)
+sed -i "s#<url>https://gitbox.apache.org/repos/asf.*</url>#<url>${origin}</url>#" pom.xml


### PR DESCRIPTION
Add basic script for migrating the scm.url value to use GitHub.